### PR TITLE
Modmake will no longer execute with empty GOROOT

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -118,10 +118,36 @@ func (i *Command) Silent() *Command {
 	return i
 }
 
-// CaptureStdin will make the executed Command pass os.Stdin to it.
+// CaptureStdin will make the executed Command pass os.Stdin to the executed process.
 func (i *Command) CaptureStdin() *Command {
+	if i.err != nil {
+		return i
+	}
 	i.stdin = os.Stdin
 	return i
+}
+
+// Stdout will capture all data written to the Command's stdout stream and write it to w.
+func (i *Command) Stdout(w io.Writer) *Command {
+	if i.err != nil {
+		return i
+	}
+	i.stdout = w
+	return i
+}
+
+// Stderr will capture all data written to the Command's stderr stream and write it to w.
+func (i *Command) Stderr(w io.Writer) *Command {
+	if i.err != nil {
+		return i
+	}
+	i.stderr = w
+	return i
+}
+
+// Output will redirect all data written to either stdout or stderr to w.
+func (i *Command) Output(w io.Writer) *Command {
+	return i.Stdout(w).Stderr(w)
 }
 
 func (i *Command) Run(ctx context.Context) error {

--- a/exec.go
+++ b/exec.go
@@ -118,7 +118,7 @@ func (i *Command) Silent() *Command {
 	return i
 }
 
-// CaptureStdin will make the executed Command pass os.Stdin to the executed process.
+// CaptureStdin will make the Command pass os.Stdin to the executed process.
 func (i *Command) CaptureStdin() *Command {
 	if i.err != nil {
 		return i

--- a/exec_test.go
+++ b/exec_test.go
@@ -2,6 +2,9 @@ package modmake
 
 import (
 	"context"
+	"github.com/stretchr/testify/assert"
+	"strings"
+	"testing"
 	"time"
 )
 
@@ -13,4 +16,15 @@ func ExampleCommand_Silent() {
 		panic(err)
 	}
 	// Output:
+}
+
+func TestCommand_Output(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var buf strings.Builder
+	err := Exec("go", "version").Output(&buf).Run(ctx)
+	t.Logf("Data written to buffer: %s", buf.String())
+	assert.NoError(t, err)
+	assert.True(t, buf.Len() > 0, "The Go version should have been written to buffer")
 }


### PR DESCRIPTION
 - Adding the capability to output Command stdout/stderr to writer.
 - If GOROOT is not defined, falling back to resolving from 'go env GOROOT'.