### PR TITLE
Allow for remote module calls

### DIFF
--- a/appbuild.go
+++ b/appbuild.go
@@ -3,9 +3,10 @@ package modmake
 import (
 	"context"
 	"fmt"
-	"github.com/saylorsolutions/modmake/assert"
 	"runtime"
 	"strings"
+
+	"github.com/saylorsolutions/modmake/assert"
 )
 
 // AppBuildFunc is a function used to customize an AppBuild or AppVariant's build step.
@@ -202,7 +203,6 @@ func (b *Build) ImportApp(a *AppBuild) {
 type AppVariant struct {
 	variant, os, arch    string
 	buildOutput, distDir PathString
-	gobuild              *GoBuild
 	buildFunc            AppBuildFunc
 	packageFunc          AppPackageFunc
 }

--- a/appbuild_test.go
+++ b/appbuild_test.go
@@ -89,9 +89,9 @@ func TestBuild_ImportApp_Default(t *testing.T) {
 	b := NewBuild()
 	a := NewAppBuild("testapp", "cmd/modmake", "1.0.0")
 	b.ImportApp(a)
-	_, ok := b.StepOk("testapp:build-testapp_localtest")
+	_, ok := b.StepOk("testapp:build-testapp_local")
 	assert.True(t, ok, "A default task should be created when no variants are added")
-	assert.Len(t, a.variants, 1)
+	assert.Len(t, a.variants, 2) // Implied install variant.
 }
 
 func TestBuild_ImportApp(t *testing.T) {
@@ -101,9 +101,9 @@ func TestBuild_ImportApp(t *testing.T) {
 	mac := a.Variant("darwin", "amd64")
 	lin := a.Variant("linux", "arm64")
 	b.ImportApp(a)
-	_, ok := b.StepOk("testapp:localtest")
+	_, ok := b.StepOk("testapp:local")
 	assert.False(t, ok, "A default task should NOT be created when variants are added")
-	assert.Len(t, a.variants, 3)
+	assert.Len(t, a.variants, 4) // An extra install variant is created.
 
 	shouldExist := []string{
 		"testapp:build-testapp_windows_amd64",
@@ -112,6 +112,7 @@ func TestBuild_ImportApp(t *testing.T) {
 		"testapp:package-testapp_darwin_amd64",
 		"testapp:build-testapp_linux_arm64",
 		"testapp:package-testapp_linux_arm64",
+		"testapp:install",
 
 		// These should be equivalent to the list above
 		"testapp:" + a.buildName(win),
@@ -120,9 +121,10 @@ func TestBuild_ImportApp(t *testing.T) {
 		"testapp:" + a.packageName(mac),
 		"testapp:" + a.buildName(lin),
 		"testapp:" + a.packageName(lin),
+		"testapp:install", // Not referencable using app, implied creation at the time of build generation.
 	}
-	for i := 6; i < len(shouldExist); i++ {
-		assert.Equal(t, shouldExist[i-6], shouldExist[i])
+	for i := 7; i < len(shouldExist); i++ {
+		assert.Equal(t, shouldExist[i-7], shouldExist[i])
 	}
 	for _, step := range shouldExist {
 		_, ok := b.StepOk(step)

--- a/build_test.go
+++ b/build_test.go
@@ -157,6 +157,17 @@ func TestSubmoduleCallBuild(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func ExampleCallBuild() {
+	callHelloWorldExample := Task(func(ctx context.Context) error {
+		return CallBuild("example/helloworld/build.go", "build").Run(ctx)
+	})
+	if err := callHelloWorldExample(context.TODO()); err != nil {
+		panic(err)
+	}
+
+	// Output:
+}
+
 func BenchmarkLargeCycle_1000(b *testing.B) {
 	build := func() *Build {
 		steps := make([]*Step, 1_000)
@@ -211,4 +222,24 @@ func TestBuild_Import(t *testing.T) {
 	assert.True(t, ok, "Step 'other:print' should have been imported")
 	_, ok = b.StepOk("print")
 	assert.False(t, ok, "Other 'print' step should not have been imported")
+}
+
+func TestCallRemote(t *testing.T) {
+	module := "github.com/saylorsolutions/modmake@v0.2.2"
+	buildPath := Path("example/helloworld/build.go")
+	err := CallRemote(module, buildPath, "build").Run(context.TODO())
+	assert.NoError(t, err)
+}
+
+func ExampleCallRemote() {
+	callHelloWorldExample := Task(func(ctx context.Context) error {
+		module := "github.com/saylorsolutions/modmake@v0.2.2"
+		buildPath := Path("example/helloworld/build.go")
+		return CallRemote(module, buildPath, "build").Run(context.TODO())
+	})
+	if err := callHelloWorldExample(context.TODO()); err != nil {
+		panic(err)
+	}
+
+	// Output:
 }

--- a/buildexec.go
+++ b/buildexec.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/fatih/color"
-	flag "github.com/spf13/pflag"
 	"log"
 	"os"
 	"os/signal"
 	"runtime/debug"
 	"strings"
 	"time"
+
+	"github.com/fatih/color"
+	flag "github.com/spf13/pflag"
 )
 
 var (
@@ -195,6 +196,6 @@ See https://github.com/saylorsolutions/modmake for detailed usage information.
 		}
 	}
 
-	log.Printf(okColor(fmt.Sprintf("Ran successfully in %s\n", time.Since(start).Round(time.Millisecond).String())))
+	log.Print(okColor(fmt.Sprintf("Ran successfully in %s\n", time.Since(start).Round(time.Millisecond).String())))
 	return nil
 }

--- a/cmd/modmake/main.go
+++ b/cmd/modmake/main.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	. "github.com/saylorsolutions/modmake"
 	"log"
 	"os"
 	"strings"
+
+	. "github.com/saylorsolutions/modmake"
 )
 
 var (
-	gitBranch = "UNKNONWN BRANCH"
+	gitBranch = "UNKNOWN BRANCH"
 	gitHash   = "UNKNOWN COMMIT"
 )
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -149,7 +149,11 @@ func main() {
             <li><code>test</code> - This step should run unit tests in the project. Depends on <code>generate</code>.</li>
             <li><code>benchmark</code> - This step is skipped by default (it's not very often that these need to be run), but the step is here when required. Depends on <code>test</code>.</li>
             <li><code>build</code> - This step is for building the code </li>
+            <li><code>package</code> - This step is for packaging executables into an easily distributable/deployable format. </li>
         </ul>
+        <aside>
+            Additionally, the steps <code>graph</code> and <code>steps</code> may not be created, as these are reserved for getting step dependencies and listing, respectively.
+        </aside>
         <h3 id="build-model_tasks">Tasks</h3>
         <p>
             At a more atomic level there exists a <code>Task</code>.

--- a/goruntime.go
+++ b/goruntime.go
@@ -156,6 +156,19 @@ func (g *GoTools) goTool() string {
 	return filepath.Join(goRootPath, "bin", "go")
 }
 
+// GetEnv will call "go env $key", and return the value of the named environment variable.
+// If an error occurs, then the call will panic.
+func (g *GoTools) GetEnv(key string) string {
+	var output bytes.Buffer
+	timeout, cancelFunc := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancelFunc()
+	err := g.Command("env", key).CaptureStdin().Stdout(&output).Run(timeout)
+	if err != nil {
+		panic(err)
+	}
+	return strings.TrimSpace(output.String())
+}
+
 // ModuleRoot returns a filesystem path to the root of the current module.
 func (g *GoTools) ModuleRoot() PathString {
 	return g.goModPath.MustGet().Dir()

--- a/goruntime.go
+++ b/goruntime.go
@@ -269,8 +269,8 @@ func (g *GoTools) ModTidy() *Command {
 	return Exec(g.goTool(), "mod", "tidy")
 }
 
-// ModuleInfo is a struct used to capture the JSON output of a module download.
-type ModuleInfo struct {
+// moduleInfo is a struct used to capture the JSON output of a module download.
+type moduleInfo struct {
 	Path     string // module path
 	Query    string // version query corresponding to this version
 	Version  string // module version
@@ -285,16 +285,16 @@ type ModuleInfo struct {
 	Reuse    bool   // reuse of old module info is safe
 }
 
-func (g *GoTools) modDownload(ctx context.Context, module string) (ModuleInfo, error) {
+func (g *GoTools) modDownload(ctx context.Context, module string) (moduleInfo, error) {
 	var (
 		output bytes.Buffer
 	)
 	if err := Go().Command("mod", "download", "-json", module).CaptureStdin().Stdout(&output).Run(ctx); err != nil {
-		return ModuleInfo{}, fmt.Errorf("failed to download module: %w", err)
+		return moduleInfo{}, fmt.Errorf("failed to download module: %w", err)
 	}
-	var mod ModuleInfo
+	var mod moduleInfo
 	if err := json.NewDecoder(bytes.NewReader(output.Bytes())).Decode(&mod); err != nil {
-		return ModuleInfo{}, fmt.Errorf("failed to decode module info: %w", err)
+		return moduleInfo{}, fmt.Errorf("failed to decode module info: %w", err)
 	}
 	return mod, nil
 }

--- a/goruntime.go
+++ b/goruntime.go
@@ -7,13 +7,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/saylorsolutions/cache"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/saylorsolutions/cache"
 )
 
 // GoTools provides some utility functions for interacting with the go tool chain.
@@ -288,12 +289,12 @@ type moduleInfo struct {
 func (g *GoTools) modDownload(ctx context.Context, module string) (moduleInfo, error) {
 	var (
 		output bytes.Buffer
+		mod    moduleInfo
 	)
 	if err := Go().Command("mod", "download", "-json", module).CaptureStdin().Stdout(&output).Run(ctx); err != nil {
 		return moduleInfo{}, fmt.Errorf("failed to download module: %w", err)
 	}
-	var mod moduleInfo
-	if err := json.NewDecoder(bytes.NewReader(output.Bytes())).Decode(&mod); err != nil {
+	if err := json.NewDecoder(&output).Decode(&mod); err != nil {
 		return moduleInfo{}, fmt.Errorf("failed to decode module info: %w", err)
 	}
 	return mod, nil

--- a/goruntime_test.go
+++ b/goruntime_test.go
@@ -87,3 +87,10 @@ func TestScanGoMod(t *testing.T) {
 	assert.True(t, found, "Should have found the root of the module")
 	assert.Equal(t, _cwd.Join("go.mod").String(), root.String(), "Current working directory should be the root of the module")
 }
+
+func TestModDownload(t *testing.T) {
+	modInfo, err := Go().modDownload(context.Background(), "github.com/saylorsolutions/modmake@v0.2.2")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, modInfo.Dir)
+	t.Logf("%#v", modInfo)
+}

--- a/goruntime_test.go
+++ b/goruntime_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 )
 
@@ -93,4 +94,17 @@ func TestModDownload(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEmpty(t, modInfo.Dir)
 	t.Logf("%#v", modInfo)
+}
+
+func TestGoTools_GetEnv(t *testing.T) {
+	cmd := exec.Command("go", "env", "GOPATH")
+	output, err := cmd.Output()
+	assert.NoError(t, err)
+	want := strings.TrimSpace(string(output))
+
+	var got string
+	assert.NotPanics(t, func() {
+		got = Go().GetEnv("GOPATH")
+	})
+	assert.Equal(t, want, got)
 }

--- a/goruntime_test.go
+++ b/goruntime_test.go
@@ -3,11 +3,12 @@ package modmake
 import (
 	"context"
 	"errors"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"os/exec"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGoTools_Test(t *testing.T) {
@@ -23,8 +24,7 @@ func TestGoTools_Build_File(t *testing.T) {
 	build := Go().Build("main.go").
 		ChangeDir("testingbuild").
 		OutputFilename("blah.exe").
-		ForceRebuild().
-		RaceDetector()
+		ForceRebuild()
 
 	b := NewBuild()
 	b.Generate().Does(Go().GenerateAll())


### PR DESCRIPTION
The idea with this feature is to allow easier installation in cases where Modmake builds are used. To support that goal, AppBuild will now include a default install step in its generated build. This makes installing tools in modules using Modmake a one-liner.

I'd also like to include a `--remote` flag to the Modmake CLI to provide similar behavior. This would just do a `go mod download` of the remote module, and invoke itself in the root of the downloaded module.