### PR TITLE
Add file watching feature to modmake CLI

### DIFF
--- a/cmd/modmake/main.go
+++ b/cmd/modmake/main.go
@@ -4,11 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	. "github.com/saylorsolutions/modmake"
 	"log"
 	"os"
 	"strings"
-
-	. "github.com/saylorsolutions/modmake"
 )
 
 var (
@@ -79,6 +78,9 @@ func runBuild(ctx context.Context, target string, flags *appFlags) error {
 			return fmt.Errorf("invalid environment variable format, '%s' must be 'KEY=VALUE'", env)
 		}
 		run.Env(strings.TrimSpace(kv[0]), strings.TrimSpace(kv[1]))
+	}
+	if len(flags.watchDir) > 0 {
+		return runWatching(ctx, run.Task(), flags)
 	}
 	return run.Run(ctx)
 }

--- a/cmd/modmake/processgate.go
+++ b/cmd/modmake/processgate.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/saylorsolutions/modmake"
+	"log"
+	"os/exec"
+	"sync/atomic"
+	"time"
+)
+
+type gateState = int32
+
+const (
+	ready           gateState = iota // ready indicates that the gate is able to start immediately.
+	starting                         // started is a transition state between ready and started.
+	settingDebounce                  // settingDebounce is used to avoid concurrent access to debounce variables.
+	started                          // started indicates that the gate is running.
+	stopping                         // stopping is a transition state between started and stopped.
+	stopped                          // stopped is a preparation state before Stop puts the gate back into ready.
+	locked                           // locked indicates that an unrecoverable error was reported from the task.
+)
+
+var (
+	ErrLocked = errors.New("process gate is locked")
+)
+
+type processGate struct {
+	base             context.Context
+	errCh            chan error
+	task             modmake.Task
+	state            atomic.Int32
+	debounceInterval time.Duration
+	cancel           context.CancelFunc
+	subCtx           context.Context
+	debounceAt       atomic.Int64
+	errHandler       func(err error) error
+	waitExit         atomic.Int64
+}
+
+func newProcessGate(ctx context.Context, debounceInterval time.Duration, task modmake.Task) *processGate {
+	return &processGate{
+		base:             ctx,
+		errCh:            make(chan error, 1),
+		cancel:           func() {},
+		debounceInterval: debounceInterval,
+		task:             task,
+		errHandler: func(err error) error {
+			exitErr := &exec.ExitError{}
+			if errors.As(err, &exitErr) {
+				log.Println("Process exited with status:", exitErr.ExitCode())
+				return nil
+			}
+			return err
+		},
+	}
+}
+
+func (g *processGate) SetExitWait(wait time.Duration) {
+	g.waitExit.Store(int64(wait))
+}
+
+func (g *processGate) Start() error {
+	if g.state.Load() == locked {
+		return ErrLocked
+	}
+	if g.getDebounce().After(time.Now()) {
+		return nil
+	}
+	if err := g.Stop(); err != nil {
+		return err
+	}
+	if !g.state.CompareAndSwap(ready, starting) {
+		return nil
+	}
+
+	g.subCtx, g.cancel = context.WithCancel(g.base)
+	go func() {
+		g.setDebounce()
+		log.Println(">>>>> Starting task")
+		g.errCh <- g.task(g.subCtx)
+		log.Println(">>>>> Task stopped")
+	}()
+	return nil
+}
+
+func (g *processGate) getDebounce() time.Time {
+	return time.UnixMilli(g.debounceAt.Load())
+}
+
+func (g *processGate) setDebounce() {
+	if !g.state.CompareAndSwap(starting, settingDebounce) {
+		return
+	}
+	old := g.debounceAt.Load()
+	_ = g.debounceAt.CompareAndSwap(old, time.Now().Add(g.debounceInterval).UnixMilli())
+	g.state.Store(started)
+}
+
+func (g *processGate) Stop() error {
+	if g.state.Load() == locked {
+		return ErrLocked
+	}
+	if g.state.CompareAndSwap(started, stopping) {
+		if err := g.stop(); err != nil {
+			g.state.Store(locked)
+			return err
+		}
+		if !g.state.CompareAndSwap(stopped, ready) {
+			// Something else already started again.
+			return nil
+		}
+	}
+	return nil
+}
+
+func (g *processGate) stop() error {
+	if !g.state.CompareAndSwap(stopping, stopped) {
+		return nil
+	}
+	var waitCh <-chan time.Time
+	wait := g.waitExit.Load()
+	if wait > 0 {
+		waitCh = time.After(time.Duration(wait))
+	}
+	g.cancel()
+	select {
+	case <-g.base.Done():
+		return g.base.Err()
+	case err, more := <-g.errCh:
+		if !more {
+			return context.Canceled
+		}
+		if err != nil {
+			if g.errHandler != nil {
+				return g.errHandler(err)
+			}
+			return err
+		}
+		return nil
+	case <-waitCh:
+		g.state.Store(locked)
+		return fmt.Errorf("%w: exit wait time '%s' elapsed", ErrLocked, time.Duration(wait).String())
+	}
+}

--- a/cmd/modmake/processgate_test.go
+++ b/cmd/modmake/processgate_test.go
@@ -18,7 +18,7 @@ func TestProcessGate_Start(t *testing.T) {
 	})
 	assert.Equal(t, 0, executed)
 	start := func() {
-		_ = gate.Start()
+		assert.NoError(t, gate.Start())
 	}
 	go start()
 	go start()
@@ -67,7 +67,7 @@ func TestProcessGate_Stop(t *testing.T) {
 	assert.Equal(t, 1, executed)
 	err := gate.Start()
 	assert.Error(t, err)
-	assert.NotErrorIs(t, err, ErrLocked, "The next call to start should report the error returned from the previous iteration")
+	assert.NotErrorIs(t, err, ErrLocked, "The next call to start should report the error returned from the previous execution")
 	time.Sleep(100 * time.Millisecond)
 	assert.Equal(t, 1, executed, "The task should not have run with a previous run returning an error")
 	assert.ErrorIs(t, gate.Stop(), ErrLocked, "The call to stop should report the gate is locked, due to the previous error")

--- a/cmd/modmake/processgate_test.go
+++ b/cmd/modmake/processgate_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestProcessGate_Start(t *testing.T) {
+	var (
+		executed int
+	)
+	gate := newProcessGate(context.Background(), 100*time.Millisecond, func(ctx context.Context) error {
+		executed++
+		return nil
+	})
+	assert.Equal(t, 0, executed)
+	start := func() {
+		_ = gate.Start()
+	}
+	go start()
+	go start()
+	go start()
+	assert.Equal(t, 0, executed)
+	time.Sleep(200 * time.Millisecond)
+	assert.Equal(t, 1, executed)
+	go start()
+	go start()
+	go start()
+	time.Sleep(200 * time.Millisecond)
+	assert.Equal(t, 2, executed)
+	assert.NoError(t, gate.Stop())
+}
+
+func TestProcessGate_SetExitWait(t *testing.T) {
+	var (
+		executed int
+	)
+	gate := newProcessGate(context.Background(), 0, func(ctx context.Context) error {
+		executed++
+		<-ctx.Done()
+		time.Sleep(time.Second)
+		return nil
+	})
+	gate.SetExitWait(100 * time.Millisecond)
+	assert.NoError(t, gate.Start())
+	assert.NoError(t, gate.Start())
+	assert.NoError(t, gate.Start())
+	time.Sleep(100 * time.Millisecond)
+	assert.Equal(t, 1, executed)
+	assert.ErrorIs(t, gate.Stop(), ErrLocked)
+}
+
+func TestProcessGate_Stop(t *testing.T) {
+	var (
+		executed int
+	)
+	gate := newProcessGate(context.Background(), 100*time.Millisecond, func(ctx context.Context) error {
+		executed++
+		return errors.New("test error")
+	})
+
+	assert.NoError(t, gate.Start())
+	time.Sleep(100 * time.Millisecond)
+	assert.Equal(t, 1, executed)
+	err := gate.Start()
+	assert.Error(t, err)
+	assert.NotErrorIs(t, err, ErrLocked, "The next call to start should report the error returned from the previous iteration")
+	time.Sleep(100 * time.Millisecond)
+	assert.Equal(t, 1, executed, "The task should not have run with a previous run returning an error")
+	assert.ErrorIs(t, gate.Stop(), ErrLocked, "The call to stop should report the gate is locked, due to the previous error")
+}

--- a/cmd/modmake/watcher.go
+++ b/cmd/modmake/watcher.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/fsnotify/fsnotify"
+	. "github.com/saylorsolutions/modmake"
+	"io/fs"
+	"log"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+func runWatching(_base context.Context, task Task, flags *appFlags) (rerr error) {
+	if flags.watchInterval <= 0 {
+		return fmt.Errorf("watch interval '%s' is invalid", flags.watchInterval.String())
+	}
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("failed to establish directory watcher: %w", err)
+	}
+	defer func() {
+		_ = watcher.Close()
+	}()
+
+	var (
+		wg           sync.WaitGroup
+		base, cancel = context.WithCancel(_base)
+	)
+	defer cancel()
+	wg.Add(1)
+	watchDir := flags.watchDirectory().String()
+	var watchDirs = []string{watchDir}
+	if flags.watchSubdirs {
+		err = filepath.Walk(watchDir, func(path string, info fs.FileInfo, err error) error {
+			if path == watchDir {
+				return nil
+			}
+			if err != nil {
+				return err
+			}
+			if info.IsDir() {
+				watchDirs = append(watchDirs, path)
+			}
+			return nil
+		})
+		if err != nil {
+			return fmt.Errorf("failed to walk '%s': %w", watchDir, err)
+		}
+	}
+
+	gate := newProcessGate(base, flags.watchInterval, task)
+	defer func() {
+		if err := gate.Stop(); err != nil {
+			rerr = err
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		var (
+			patterns = flags.watchPatterns()
+			match    = func(path string) bool {
+				return true
+			}
+		)
+		if len(patterns) > 0 {
+			match = func(name string) bool {
+				for _, pattern := range patterns {
+					pattern = strings.TrimSpace(pattern)
+					matched, err := filepath.Match(pattern, filepath.Base(name))
+					if err != nil {
+						continue
+					}
+					if matched {
+						return true
+					}
+				}
+				return false
+			}
+		}
+		if err := gate.Start(); err != nil {
+			rerr = err
+			return
+		}
+		for {
+			select {
+			case <-base.Done():
+				rerr = gate.Stop()
+				return
+			case event, ok := <-watcher.Events:
+				if !ok {
+					return
+				}
+				if match(event.Name) {
+					log.Printf("Received event: %s\n", event.String())
+					if err := gate.Start(); err != nil {
+						rerr = err
+						return
+					}
+				}
+			case err := <-watcher.Errors:
+				rerr = fmt.Errorf("error watching directory '%s': %w", watchDir, err)
+				return
+			}
+		}
+	}()
+
+	for _, watchDir := range watchDirs {
+		if err := watcher.Add(watchDir); err != nil {
+			return fmt.Errorf("failed to watch directory '%s': %w", watchDir, err)
+		}
+	}
+	wg.Wait()
+	if rerr != nil {
+		return rerr
+	}
+	return nil
+}

--- a/exec.go
+++ b/exec.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"syscall"
 	"time"
 )
 
@@ -166,7 +165,7 @@ func (i *Command) Run(ctx context.Context) error {
 		cmd.Stderr = i.stderr
 		cmd.Stdin = i.stdin
 		cmd.Dir = i.workdir
-		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+		customizeCmd(cmd)
 		cmd.Cancel = cancelIncludeChildren(cmd)
 		cmd.WaitDelay = 5 * time.Second
 		if err := cmd.Start(); err != nil {

--- a/exec.go
+++ b/exec.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"time"
 )
 
 type Command struct {
@@ -167,11 +166,7 @@ func (i *Command) Run(ctx context.Context) error {
 		cmd.Dir = i.workdir
 		customizeCmd(cmd)
 		cmd.Cancel = cancelIncludeChildren(cmd)
-		cmd.WaitDelay = 5 * time.Second
-		if err := cmd.Start(); err != nil {
-			return err
-		}
-		if err := cmd.Wait(); err != nil {
+		if err := cmd.Run(); err != nil {
 			return err
 		}
 		return nil

--- a/exec.go
+++ b/exec.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
+	"syscall"
 	"time"
 )
 
@@ -166,16 +166,8 @@ func (i *Command) Run(ctx context.Context) error {
 		cmd.Stderr = i.stderr
 		cmd.Stdin = i.stdin
 		cmd.Dir = i.workdir
-		cmd.Cancel = func() error {
-			if cmd.Process != nil {
-				if runtime.GOOS == "windows" {
-					return cmd.Process.Kill()
-				} else {
-					return cmd.Process.Signal(os.Interrupt)
-				}
-			}
-			return nil
-		}
+		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+		cmd.Cancel = cancelIncludeChildren(cmd)
 		cmd.WaitDelay = 5 * time.Second
 		if err := cmd.Start(); err != nil {
 			return err

--- a/exec_nix.go
+++ b/exec_nix.go
@@ -1,0 +1,17 @@
+//go:build !windows
+
+package modmake
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func cancelIncludeChildren(cmd *exec.Cmd) func() error {
+	return func() error {
+		if cmd.Process != nil {
+			return syscall.Kill(-cmd.Process.Pid, syscall.SIGINT)
+		}
+		return nil
+	}
+}

--- a/exec_nix.go
+++ b/exec_nix.go
@@ -7,6 +7,11 @@ import (
 	"syscall"
 )
 
+func customizeCmd(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	return
+}
+
 func cancelIncludeChildren(cmd *exec.Cmd) func() error {
 	return func() error {
 		if cmd.Process != nil {

--- a/exec_windows.go
+++ b/exec_windows.go
@@ -2,7 +2,12 @@ package modmake
 
 import (
 	"os/exec"
+	"strconv"
 )
+
+func customizeCmd(_ *exec.Cmd) {
+	return
+}
 
 func cancelIncludeChildren(cmd *exec.Cmd) func() error {
 	return func() error {

--- a/exec_windows.go
+++ b/exec_windows.go
@@ -1,0 +1,14 @@
+package modmake
+
+import (
+	"os/exec"
+)
+
+func cancelIncludeChildren(cmd *exec.Cmd) func() error {
+	return func() error {
+		if cmd.Process != nil {
+			return exec.Command("TASKKILL", "/T", "/F", "/PID", strconv.Itoa(cmd.Process.Pid)).Run()
+		}
+		return nil
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/saylorsolutions/modmake
 
-go 1.19
+go 1.20
 
 require (
 	github.com/fatih/color v1.16.0

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/fatih/color v1.16.0
+	github.com/fsnotify/fsnotify v1.7.0
 	github.com/go-git/go-billy/v5 v5.5.0
 	github.com/go-git/go-git/v5 v5.11.0
 	github.com/saylorsolutions/cache v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
+github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
+github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/gliderlabs/ssh v0.3.5 h1:OcaySEmAQJgyYcArR+gGGTHCyE7nvhEMTlYY+Dp8CpY=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 h1:+zs/tPmkDkHx3U66DAb0lQFJrpS6731Oaa12ikc+DiI=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376/go.mod h1:an3vInlBmSxCcxctByoQdvwPiA7DTK7jaaFDBTtu0ic=

--- a/modmake/build.go
+++ b/modmake/build.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	version = "0.3.1"
+	version = "0.4.0"
 )
 
 var (


### PR DESCRIPTION
* Updating Exec task to make sure that child processes also stop before returning.
* Added `fsnotify` to dependencies for file watching.
* Added more flags to CLI to accommodate file watching behavior.