### PR TITLE
Fixing use of modmake-docs and other improvements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/saylorsolutions/modmake
 
-go 1.20
+go 1.21
 
 require (
-	github.com/fatih/color v1.16.0
+	github.com/fatih/color v1.17.0
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/saylorsolutions/cache v1.2.0
 	github.com/spf13/pflag v1.0.5
@@ -16,8 +16,8 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/rogpeppe/go-internal v1.11.0 // indirect
-	golang.org/x/sys v0.18.0 // indirect
+	github.com/rogpeppe/go-internal v1.12.0 // indirect
+	golang.org/x/sys v0.20.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
-github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
+github.com/fatih/color v1.17.0 h1:GlRw1BRJxkpqUCBKzKOw098ed57fEsKeNjpTe3cSjK4=
+github.com/fatih/color v1.17.0/go.mod h1:YZ7TlrGPkiz6ku9fK3TLD/pl3CpsiFyu8N92HLgmosI=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
@@ -21,8 +21,8 @@ github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsK
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
-github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
-github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
+github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
+github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/saylorsolutions/cache v1.2.0 h1:H6nI/aZY2F87MMUR+Iz1UHS+areQ6z/kGymD0gRW8es=
 github.com/saylorsolutions/cache v1.2.0/go.mod h1:NXWMylDOfhrn9Jju2GnYXPlWCMDntw2rA9PBT3F0We8=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
@@ -31,8 +31,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.18.0 h1:DBdB3niSjOA/O0blCZBqDefyWNYveAYMNF1Wum0DYQ4=
-golang.org/x/sys v0.18.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.20.0 h1:Od9JTbYCk261bKm4M/mw7AklTlFYIa0bIp9BgSm1S8Y=
+golang.org/x/sys v0.20.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=

--- a/pkg/git/clone.go
+++ b/pkg/git/clone.go
@@ -1,0 +1,10 @@
+package git
+
+import (
+	"github.com/saylorsolutions/modmake"
+)
+
+// CloneAt will clone the repository identified by repo at the given destination.
+func CloneAt(repo string, destination modmake.PathString) modmake.Task {
+	return Exec("clone", repo, destination.String()).Run
+}

--- a/pkg/git/doc.go
+++ b/pkg/git/doc.go
@@ -1,0 +1,8 @@
+/*
+Package git provides some helpers for using the Git CLI in Modmake builds.
+This includes:
+  - Updating submodules with "--init" or "--remote"
+  - Cloning repositories
+  - Getting commit and branch details
+*/
+package git

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -45,9 +45,7 @@ func ExecOutputCtx(ctx context.Context, subcmd string, args ...string) (string, 
 	var (
 		buf strings.Builder
 	)
-	timeout, cancel := context.WithTimeout(ctx, ExecTimeout)
-	defer cancel()
-	if err := Exec(subcmd, args...).Output(&buf).Run(timeout); err != nil {
+	if err := Exec(subcmd, args...).Output(&buf).Run(ctx); err != nil {
 		return buf.String(), err
 	}
 	return strings.TrimSpace(buf.String()), nil

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -13,7 +13,8 @@ import (
 )
 
 var (
-	ErrNoGit = errors.New("unable to locate git executable")
+	ErrNoGit    = errors.New("unable to locate git executable")
+	ExecTimeout = 5 * time.Second // Used to limit how long [Exec] should operate. May be overridden.
 )
 
 // Exec will produce a [modmake.Command] that executes a git command.
@@ -26,14 +27,14 @@ func Exec(subcmd string, args ...string) *modmake.Command {
 	if len(path) == 0 {
 		panic(ErrNoGit)
 	}
-	return modmake.Exec(append([]string{"git", subcmd}, args...)...).CaptureStdin()
+	return modmake.Exec(append([]string{path, subcmd}, args...)...).CaptureStdin()
 }
 
 // ExecOutput will delegate to Exec and run the returned [modmake.Command], but will collect its output into a string.
-// This will also set a max execution time of 5 seconds.
+// This will also use the execution limit of [ExecTimeout].
 // If you want to override this timeout or exit after some other condition, then use [ExecOutputCtx].
 func ExecOutput(subcmd string, args ...string) (string, error) {
-	timeout, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	timeout, cancel := context.WithTimeout(context.Background(), ExecTimeout)
 	defer cancel()
 	return ExecOutputCtx(timeout, subcmd, args...)
 }
@@ -44,8 +45,10 @@ func ExecOutputCtx(ctx context.Context, subcmd string, args ...string) (string, 
 	var (
 		buf strings.Builder
 	)
-	if err := Exec(subcmd, args...).Output(&buf).Run(ctx); err != nil {
-		return "", err
+	timeout, cancel := context.WithTimeout(ctx, ExecTimeout)
+	defer cancel()
+	if err := Exec(subcmd, args...).Output(&buf).Run(timeout); err != nil {
+		return buf.String(), err
 	}
 	return strings.TrimSpace(buf.String()), nil
 }

--- a/pkg/git/submodules.go
+++ b/pkg/git/submodules.go
@@ -4,7 +4,7 @@ import (
 	"github.com/saylorsolutions/modmake"
 )
 
-// SubmoduleUpdateInit will run 'git submodule update --init <path>'.
+// SubmoduleUpdateInit will run 'git submodule update --init <path>', using path if it's given.
 func SubmoduleUpdateInit(path ...string) modmake.Task {
 	args := []string{"update", "--init"}
 	if len(path) > 0 {
@@ -13,7 +13,7 @@ func SubmoduleUpdateInit(path ...string) modmake.Task {
 	return Exec("submodule", args...).Task()
 }
 
-// SubmoduleUpdateRemote will run 'git submodule update --remote <path>'.
+// SubmoduleUpdateRemote will run 'git submodule update --remote <path>', using path if it's given.
 func SubmoduleUpdateRemote(path ...string) modmake.Task {
 	args := []string{"update", "--remote"}
 	if len(path) > 0 {

--- a/script.go
+++ b/script.go
@@ -11,8 +11,8 @@ import (
 )
 
 // Script will execute each Task in order, returning the first error.
-func Script(fns ...Runner) Runner {
-	return Task(func(ctx context.Context) error {
+func Script(fns ...Runner) Task {
+	return func(ctx context.Context) error {
 		for i, fn := range fns {
 			run := ContextAware(fn)
 			if err := run.Run(ctx); err != nil {
@@ -20,7 +20,7 @@ func Script(fns ...Runner) Runner {
 			}
 		}
 		return nil
-	})
+	}
 }
 
 // IfNotExists will skip executing the Runner if the given file exists, returning nil.

--- a/task.go
+++ b/task.go
@@ -96,6 +96,22 @@ func (t Task) Catch(catch func(error) Task) Task {
 	}
 }
 
+// Finally can be used to run a function after a [Task] executes, regardless whether it was successful.
+//
+// The given function will receive the error returned from the base [Task], and may be nil.
+// If the given function returns a non-nil error, it will be returned from the produced function.
+// Otherwise, the error from the underlying [Task] will be returned.
+func (t Task) Finally(finally func(err error) error) Task {
+	return func(ctx context.Context) (terr error) {
+		defer func() {
+			if err := finally(terr); err != nil {
+				terr = err
+			}
+		}()
+		return t.Run(ctx)
+	}
+}
+
 func (t Task) Debounce(interval time.Duration) Task {
 	if interval <= time.Duration(0) {
 		panic(fmt.Sprintf("invalid debounce interval: %d", int64(interval)))

--- a/task_test.go
+++ b/task_test.go
@@ -95,3 +95,19 @@ func TestTask_Debounce(t *testing.T) {
 	assert.NoError(t, task(ctx))
 	assert.Equal(t, 2, executed)
 }
+
+func TestTask_Finally(t *testing.T) {
+	var didFinally bool
+	task := Plain(func() {
+		assert.False(t, didFinally, "'didFinally' should not have been set yet")
+	}).
+		Finally(func(_ error) error {
+			didFinally = true
+			return nil
+		}).
+		Finally(func(_ error) error {
+			assert.True(t, didFinally, "Should have done finally")
+			return nil
+		})
+	assert.NoError(t, task.Run(context.Background()))
+}

--- a/tmp.go
+++ b/tmp.go
@@ -1,0 +1,33 @@
+package modmake
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// TempDir will create a temporary directory at the system's default temp location with the provided pattern, like [os.MkdirTemp].
+// The created [PathString] will be passed to the given function for use.
+//
+// The temp directory will be removed after this [Task] returns, or if the function panics.
+func TempDir(pattern string, fn func(tmp PathString) Task) Task {
+	return TempDirAt("", pattern, fn)
+}
+
+// TempDirAt will operate just like [TempDir], but allows specifying a location for the creation of the temp directory.
+func TempDirAt(location, pattern string, fn func(tmp PathString) Task) Task {
+	dir, err := os.MkdirTemp(location, pattern)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to create temp directory with pattern '%s' and location '%s': %v", pattern, location, err))
+	}
+	dirPath := Path(filepath.ToSlash(dir))
+	defer func() {
+		if r := recover(); r != nil {
+			_ = os.RemoveAll(dir)
+			panic(fmt.Sprintf("Encountered panic in TempDir function using temp dir '%s': %v", dir, r))
+		}
+	}()
+	return fn(dirPath).Finally(func(_ error) error {
+		return dirPath.RemoveAll()
+	})
+}

--- a/tmp_test.go
+++ b/tmp_test.go
@@ -1,0 +1,31 @@
+package modmake
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestTempDir(t *testing.T) {
+	var dir PathString
+	err := TempDir("TestTempDir-*", func(tmp PathString) Task {
+		assert.True(t, tmp.Exists(), "temp dir should be created before the produced task is run")
+		return Plain(func() {
+			dir = tmp
+			assert.True(t, tmp.Exists())
+		})
+	}).Run(context.Background())
+	assert.NoError(t, err)
+	assert.False(t, dir.Exists())
+
+	dir = ""
+	assert.Panics(t, func() {
+		TempDir("TestTempDir-*", func(tmp PathString) Task {
+			dir = tmp
+			assert.True(t, tmp.Exists(), "Again, tmp should exist at this point")
+			panic("panic while producing Task")
+		})
+	})
+	assert.NotEqual(t, "", dir.String())
+	assert.False(t, dir.Exists(), "Temp directory should still be removed if the Task producer function panics")
+}


### PR DESCRIPTION
 - Added TempDir tasks for working with temp directories.
 - Fixing git.Exec to use the found path for Git, and to use a configurable timeout duration.
 - Adding Task.Finally to support TempDir.