### PR TITLE
Test step fix

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-MIT License
+MIT License with Commons Clause
 
 Copyright (c) 2023 Joseph D. Saylor
 
@@ -19,3 +19,25 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+
+"Commons Clause" License Condition v1.0
+
+The Software is provided to you by the Licensor under the License, as defined
+below, subject to the following condition.
+
+Without limiting other conditions in the License, the grant of rights under
+the License will not include, and the License does not grant to you, right to
+Sell the Software.
+
+For purposes of the foregoing, "Sell" means practicing any or all of the
+rights granted to you under the License to provide to third parties, for a fee
+or other consideration (including without limitation fees for hosting or
+consulting/support services related to the Software), a product or service
+whose value derives, entirely or substantially, from the functionality of the
+Software. Any license notice or attribution required by the License must also
+include this Commons Cause License Condition notice.
+
+Software: Modmake
+License: MIT
+Licensor: Joseph D. Saylor

--- a/build.go
+++ b/build.go
@@ -29,6 +29,19 @@ type Build struct {
 	stepNames map[string]*Step
 }
 
+var hasTested bool
+var testOnce Task = func(ctx context.Context) error {
+	if hasTested {
+		return nil
+	}
+	return Script(
+		Go().TestAll(),
+		Plain(func() {
+			hasTested = true
+		}),
+	).Run(ctx)
+}
+
 // NewBuild constructs a new Build with the standard structure.
 // This includes the following steps:
 //   - tools for installing and verifying required tooling.
@@ -40,7 +53,7 @@ type Build struct {
 func NewBuild() *Build {
 	tools := newStep("tools", "Installs external tools that will be needed later")
 	generate := newStep("generate", "Generates code, possibly using external tools").DependsOn(tools)
-	test := newStep("test", "Runs unit tests on the code base").DependsOn(generate).Does(Go().TestAll())
+	test := newStep("test", "Runs unit tests on the code base").DependsOn(generate).Does(testOnce)
 	bench := newStep("benchmark", "Runs benchmarking on the code base").DependsOn(test).Does(Go().BenchmarkAll())
 	build := newStep("build", "Builds the code base and outputs an artifact").DependsOn(bench)
 	pkg := newStep("package", "Bundles one or more built artifacts into one or more distributable packages").DependsOn(build)

--- a/goversion.go
+++ b/goversion.go
@@ -18,16 +18,22 @@ var (
 	_goVersionCache map[int]string
 )
 
-// PinLatest will replace the cached [GoTools] instance with one pinned to the latest patch version of the specified minor version.
+// PinLatest just defers to [GoTools.PinLatestV1].
+//
+// Deprecated: Use PinLatestV1 instead to disambiguate if there's ever a go v2.
+func (g *GoTools) PinLatest(minorVersion int) *GoTools {
+	return g.PinLatestV1(minorVersion)
+}
+
+// PinLatestV1 will replace the cached [GoTools] instance with one pinned to the latest patch version of the specified minor version.
 // To revert back to the system go version, use [GoTools.InvalidateCache].
 //
 // Note: For safety reasons, unstable release candidate versions are not considered.
 // If there is not a stable version available, then this function will panic.
-func (g *GoTools) PinLatest(minorVersion int) *GoTools {
+func (g *GoTools) PinLatestV1(minorVersion int) *GoTools {
 	_goMux.RLock()
 	curSysInstance := _goInstance
 	_goMux.RUnlock()
-	_goInstance = nil
 	// Grab the current system go binary directory
 	curGoBinPath := Path(curSysInstance.GetEnv("GOPATH"), "bin")
 	// Get the latest patch version to pin to
@@ -49,6 +55,7 @@ func (g *GoTools) PinLatest(minorVersion int) *GoTools {
 		panic(err)
 	}
 	// Initialize the new GoTools instance
+	_goInstance = nil
 	pinnedInstance, err := initGoInstNamed(pinnedGo.String())
 	if err != nil {
 		panic(fmt.Errorf("failed to initialize pinned go version '%s': %w", version, err))

--- a/goversion_test.go
+++ b/goversion_test.go
@@ -19,9 +19,13 @@ func TestGoTools_PinLatest(t *testing.T) {
 
 	buf.Reset()
 	assert.NotPanics(t, func() {
-		inst = Go().PinLatest(6)
+		inst = Go().PinLatestV1(6)
 	})
 	assert.NoError(t, inst.Command("version").Output(&buf).Run(context.Background()))
+	assert.Contains(t, buf.String(), "1.6.4")
+
+	buf.Reset()
+	assert.NoError(t, Go().Command("version").Output(&buf).Run(context.Background()))
 	assert.Contains(t, buf.String(), "1.6.4")
 
 	buf.Reset()

--- a/modmake/build.go
+++ b/modmake/build.go
@@ -14,7 +14,7 @@ const (
 )
 
 func main() {
-	Go().PinLatest(latestGo)
+	Go().PinLatestV1(latestGo)
 	b := NewBuild()
 	b.Tools().DependsOnRunner("install-modmake-docs", "",
 		TempDir("modmake-docs-*", func(tmp PathString) Task {


### PR DESCRIPTION
A few minor improvements:
* Adding commons clause to license
* Fixing default test step to prevent running tests twice
* Adding `V1` to pin Go version call to disambiguate in case Go ever reaches a v2.

Resolves #57 